### PR TITLE
Update portuguese

### DIFF
--- a/packages/frontend/src/translations/pt.global.json
+++ b/packages/frontend/src/translations/pt.global.json
@@ -248,7 +248,7 @@
 
     "verifyAccount": {        
         "title": "Quase lá! Verifique sua nova conta.",
-        "desc": "Para prevenir spam de novas contas, nós precisamos verificar que você é o proprietário. Você pode verificar usando um código de verificação ou fazendo um pequeno depósito inicial.",
+        "desc": "Para prevenir spam de novas contas, nós precisamos validar sua operação. Você pode verificar através de um código de utilização única ou através de um pequeno depósito inicial.",
         "options": {
             "passCode": "Código de verificação",
             "initialDeposit": "Depósito inicial"


### PR DESCRIPTION
Hi,

This PR updates the translation text for portuguese language. The person that I chose in the workshop was Person 2. All translated keys were over the account verify screen, but I couldn't get that screen on my localhost env. To see the results I used mainnet, where I could reach the screen. Here are the result:

![near-ptbr](https://user-images.githubusercontent.com/45071084/138518892-67fcf09b-dfcb-44ce-9d9e-1d7fb1cf06d7.png)

Some words, terms and phrases founded were a little different from what I used to see, but using the context I could understand some of them. Like 'one-time passcode' that I translated to 'código de verificação'. In case of 'single-use funding address', I translated to 'endereço de financiamento de uso único', but with a little of doubt if was the best translation. Please, feel free to suggest changes in any case you deem inappropriate, it is my first official translation.

